### PR TITLE
Change shebang to environment

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # http://pi-hole.net
 # Compiles a list of ad-serving domains by downloading them from multiple sources
 


### PR DESCRIPTION
Find bash in the environment, not hard coded to path