### PR TITLE
fixes #126

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -231,6 +231,9 @@ sudo wget https://github.com/jacobsalmela/AdminLTE/archive/master.zip -O /var/ww
 sudo unzip -oq /var/www/master.zip -d /var/www/html/
 sudo mv /var/www/html/AdminLTE-master /var/www/html/admin
 sudo rm /var/www/master.zip 2>/dev/null
+sudo touch /var/log/pihole.log
+sudo chmod 644 /var/log/pihole.log
+sudo chown dnsmasq:root /var/log/pihole.log
 }
 
 installPiholeWeb(){


### PR DESCRIPTION
These commands were left out, resulting in the Web interface not showing ads blocked despite the Pi-hole working.  It is just a permissions error.